### PR TITLE
Add post processing for printing minutes

### DIFF
--- a/myhpi/core/templates/core/minutes.html
+++ b/myhpi/core/templates/core/minutes.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load static %}
 {% load wagtailmarkdown %}
 
 {% block content %}
@@ -26,6 +27,11 @@
             <h4 class="d-print-none">Table of contents</h4>
             {{ parsed_md.1 }}
         </div>
+        <div id="minutes-footer" class="d-none d-print-block"></div>
         {% endwith %}
     </div>
+{% endblock %}
+
+{% block extra_js %}
+<script type="text/javascript" src="{% static 'js/print_processor.js' %}"></script>
 {% endblock %}

--- a/myhpi/static/css/myHPI.css
+++ b/myhpi/static/css/myHPI.css
@@ -226,4 +226,9 @@ h1.toc-title::after {
     .minutes-text {
         order: 2;
     }
+
+    #minutes-footer {
+        margin-top: 50px;
+        order: 3;
+    }
 }

--- a/myhpi/static/js/print_processor.js
+++ b/myhpi/static/js/print_processor.js
@@ -1,0 +1,83 @@
+
+function processPageForPrinting() {
+    moveLinksToFooter();
+    expandAbbreviations();
+}
+
+function moveLinksToFooter() {
+    let content = document.getElementsByClassName("minutes-text")[0];
+    if (!content) return;
+
+    let footer = document.getElementById("minutes-footer");
+    let linkList = document.createElement("ol");
+
+    let articleLinks = content.getElementsByTagName("a");
+    for(let i=0; i<articleLinks.length; i++){
+          const articleLink = articleLinks[i];
+          articleLink.innerHTML += "<sup class='print-generated-tag'>["+(i + 1)+"]</sup>";
+          let footnote = document.createElement("li");
+          footnote.innerText = articleLink.href;
+          linkList.appendChild(footnote);
+    }
+    footer.appendChild(linkList);
+}
+
+function expandAbbreviations() {
+    let content = document.getElementsByClassName("minutes-text")[0];
+    if (!content) return;
+    let abbreviations = content.getElementsByTagName("abbr");
+    for(let i=0; i<abbreviations.length; i++) {
+        let short = abbreviations[i].innerText;
+        let long = abbreviations[i].getAttribute("title");
+
+        let replacement = document.createElement("span");
+        replacement.classList.add("print-expanded-abbr");
+        replacement.setAttribute("short", short);
+        replacement.setAttribute("long", long);
+        replacement.innerText = long;
+        abbreviations[i].parentNode.replaceChild(replacement, abbreviations[i]);
+    }
+}
+
+function removePrintingProcessing() {
+    let content = document.getElementsByClassName("minutes-text")[0];
+    if (!content) return;
+    let footer = document.getElementById("minutes-footer");
+    footer.innerText = "";
+
+    let generated = document.getElementsByClassName('print-generated-tag');
+    while (generated.length > 0) {
+        generated[0].remove();
+    }
+
+    let abbreviationReplacements = content.getElementsByClassName("print-expanded-abbr");
+    for(let i=0; i<abbreviationReplacements.length; i++) {
+        let replacement = abbreviationReplacements[i];
+        let short = replacement.getAttribute("short");
+        let long = replacement.getAttribute("long");
+
+        let abbr = document.createElement("abbr");
+        abbr.setAttribute("title", long);
+        abbr.innerText = short;
+        replacement.parentNode.replaceChild(abbr, replacement);
+    }
+}
+
+
+// Is triggered when debugging printing (Firefox)
+let mql = window.matchMedia('print');
+// mql.addEventListener('change', checkPrintStatus);
+
+function checkPrintStatus(e) {
+  if (e.matches) {
+    processPageForPrinting();
+  } else {
+    removePrintingProcessing();
+  }
+}
+
+// Is triggered when actually printing
+addEventListener("beforeprint", processPageForPrinting);
+addEventListener("afterprint", removePrintingProcessing);
+
+

--- a/myhpi/static/js/print_processor.js
+++ b/myhpi/static/js/print_processor.js
@@ -12,12 +12,12 @@ function moveLinksToFooter() {
     let linkList = document.createElement("ol");
 
     let articleLinks = content.getElementsByTagName("a");
-    for(let i=0; i<articleLinks.length; i++){
-          const articleLink = articleLinks[i];
-          articleLink.innerHTML += "<sup class='print-generated-tag'>["+(i + 1)+"]</sup>";
-          let footnote = document.createElement("li");
-          footnote.innerText = articleLink.href;
-          linkList.appendChild(footnote);
+    for (let i = 0; i < articleLinks.length; i++) {
+        const articleLink = articleLinks[i];
+        articleLink.innerHTML += "<sup class='print-generated-tag'>[" + (i + 1) + "]</sup>";
+        let footnote = document.createElement("li");
+        footnote.innerText = articleLink.href;
+        linkList.appendChild(footnote);
     }
     footer.appendChild(linkList);
 }
@@ -26,7 +26,7 @@ function expandAbbreviations() {
     let content = document.getElementsByClassName("minutes-text")[0];
     if (!content) return;
     let abbreviations = content.getElementsByTagName("abbr");
-    for(let i=0; i<abbreviations.length; i++) {
+    for (let i = 0; i < abbreviations.length; i++) {
         let short = abbreviations[i].innerText;
         let long = abbreviations[i].getAttribute("title");
 
@@ -51,7 +51,7 @@ function removePrintingProcessing() {
     }
 
     let abbreviationReplacements = content.getElementsByClassName("print-expanded-abbr");
-    for(let i=0; i<abbreviationReplacements.length; i++) {
+    for (let i = 0; i < abbreviationReplacements.length; i++) {
         let replacement = abbreviationReplacements[i];
         let short = replacement.getAttribute("short");
         let long = replacement.getAttribute("long");
@@ -63,21 +63,5 @@ function removePrintingProcessing() {
     }
 }
 
-
-// Is triggered when debugging printing (Firefox)
-let mql = window.matchMedia('print');
-// mql.addEventListener('change', checkPrintStatus);
-
-function checkPrintStatus(e) {
-  if (e.matches) {
-    processPageForPrinting();
-  } else {
-    removePrintingProcessing();
-  }
-}
-
-// Is triggered when actually printing
 addEventListener("beforeprint", processPageForPrinting);
 addEventListener("afterprint", removePrintingProcessing);
-
-


### PR DESCRIPTION
Closes #66, #69 and implements better handling for links (numbers and a list at the bottom of the page) and abbreviations (expands them).

There is still a remaining problem. When only one link is present, the rendering breaks on Firefox for unknown reasons. It works with multiple links on Firefox, it works with one or more links on Chromium, I have only observed this one weird case. We need to decide if that is ok, since it is only one edge case, if we should display a warning in that one case or if that needs to be fixed, which I have no idea how to do.

Firefox correct:
![image](https://user-images.githubusercontent.com/6863832/172315083-c10f4ed1-721e-4d7c-a1b2-4fb0060a3428.png)

Chromium correct:
![image](https://user-images.githubusercontent.com/6863832/172315293-5d8f2b32-e711-46b2-bdb0-f61b424c864f.png)

Firefox incorrect with one link:
![image](https://user-images.githubusercontent.com/6863832/172317021-bcaef6ed-5d5a-4c2e-b0d5-3dde45b8fdde.png)

Chromium correct with one link:
![image](https://user-images.githubusercontent.com/6863832/172317193-3dd14452-d171-4b99-affe-a07abb48d5f6.png)

