### PR TITLE
Add table for minute list

### DIFF
--- a/myhpi/core/models.py
+++ b/myhpi/core/models.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from django import forms
 from django.contrib.auth.models import Group, User
 from django.db import models
@@ -60,9 +62,14 @@ class MinutesList(Page):
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
         minutes_ids = self.get_children().exact_type(Minutes).values_list("id", flat=True)
-        context.setdefault(
-            "minutes_list", Minutes.objects.filter(id__in=minutes_ids, group=self.group)
+        minutes_list = (
+            Minutes.objects.filter(id__in=minutes_ids, group=self.group).order_by("date").reverse()
         )
+        context.setdefault("minutes_list", minutes_list)
+        minutes_by_years = defaultdict(lambda: [])
+        for minute in minutes_list:
+            minutes_by_years[minute.date.year].append(minute)
+        context["minutes_by_years"] = dict(minutes_by_years)
         return context
 
 

--- a/myhpi/core/templates/core/minutes_list.html
+++ b/myhpi/core/templates/core/minutes_list.html
@@ -3,26 +3,27 @@
 
 {% block content %}
 <h1>{{ page.title }}</h1>
-<ul>
-    <table class="table table-striped">
-    {% for minute in minutes_list %}
-        <tr>
-            <td><a href="{% pageurl minute %}">{{ minute.date|date:"d.m.Y" }}</a></td>
-            <td>
-                {% if not minute.live %}
-                    <span title="Draft" aria-hidden="true">⚠️</span>
-                {% endif %}
-            </td>
-            <td>
-                {% if minute.labels.all %}
-                    {% for label in minute.labels.all %}
-                        <span class="badge label-badge">{{ label }}</span>
-                    {% endfor %}
-                {% endif %}
-            </td>
-            <td><a href="{% pageurl minute %}">{{ minute.title }}</a></td>
-        </tr>
+    {% for year,minutes in minutes_by_years.items %}
+        <h3 id="year{{ year }}">{{ year }}</h3>
+        <table class="table table-striped">
+        {% for minute in minutes %}
+            <tr>
+                <td><a href="{% pageurl minute %}">{{ minute.date|date:"d.m.Y" }}</a></td>
+                <td>
+                    {% if not minute.live %}
+                        <span title="Draft" aria-hidden="true">⚠️</span>
+                    {% endif %}
+                </td>
+                <td>
+                    {% if minute.labels.all %}
+                        {% for label in minute.labels.all %}
+                            <span class="badge label-badge">{{ label }}</span>
+                        {% endfor %}
+                    {% endif %}
+                </td>
+                <td><a href="{% pageurl minute %}">{{ minute.title }}</a></td>
+            </tr>
+        {% endfor %}
+        </table>
     {% endfor %}
-    </table>
-</ul>
 {% endblock %}

--- a/myhpi/core/templates/core/minutes_list.html
+++ b/myhpi/core/templates/core/minutes_list.html
@@ -4,8 +4,25 @@
 {% block content %}
 <h1>{{ page.title }}</h1>
 <ul>
+    <table class="table table-striped">
     {% for minute in minutes_list %}
-        <li><a href="{% pageurl minute %}">{{ minute.title }} ({{ minute.date }}) {% if minute.labels.all %}({{ minute.labels.all|join:"," }}) {% endif %}</a></li>
+        <tr>
+            <td><a href="{% pageurl minute %}">{{ minute.date|date:"d.m.Y" }}</a></td>
+            <td>
+                {% if not minute.live %}
+                    <span title="Draft" aria-hidden="true">⚠️</span>
+                {% endif %}
+            </td>
+            <td>
+                {% if minute.labels.all %}
+                    {% for label in minute.labels.all %}
+                        <span class="badge label-badge">{{ label }}</span>
+                    {% endfor %}
+                {% endif %}
+            </td>
+            <td><a href="{% pageurl minute %}">{{ minute.title }}</a></td>
+        </tr>
     {% endfor %}
+    </table>
 </ul>
 {% endblock %}

--- a/myhpi/static/css/myHPI.css
+++ b/myhpi/static/css/myHPI.css
@@ -205,6 +205,10 @@ h1.toc-title::after {
     height: 0px;
 }
 
+.label-badge {
+    background-color: var(--bs-secondary);
+}
+
 @media print {
     .toc {
         display: none;


### PR DESCRIPTION
Closes #87.

Remaining issues:
- ~~Labels do not have an associated color, so the secondary color is used~~ -> moved to #95 
- ~~Font awesome icons are not yet available~~ -> Not entirely relevant for this PR since currently only one icon is needed
- ~~It is not clear what should be shown in the permissions field~~ -> See discussion on #87
- ~~There is no separation by years, since it does not seem immediately important~~ Done.

![image](https://user-images.githubusercontent.com/6863832/173226007-7d2cc7e8-2a21-4c06-8155-6b72f0f82c81.png)
