### PR TITLE
Auto assign reviewers for dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-assign.yml
+++ b/.github/workflows/dependabot-assign.yml
@@ -1,0 +1,13 @@
+name: dependabot-assign
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  assign:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: delivery-much/actions-assigner@v1
+        with:
+          token: ${{ secrets.ADMIN_PAT }}
+          team-reviewers: myhpi-dependencies


### PR DESCRIPTION
Will auto-assign reviewers of the "myhpi-dependencies" group to dependabot PRs.