### PR TITLE
Remove warnings from migrations

### DIFF
--- a/myhpi/core/migrations/0002_minutes.py
+++ b/myhpi/core/migrations/0002_minutes.py
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
                 (
                     "author",
                     models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE,
+                        on_delete=models.PROTECT,
                         related_name="author",
                         to=settings.AUTH_USER_MODEL,
                     ),
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
                 (
                     "moderator",
                     models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE,
+                        on_delete=models.PROTECT,
                         related_name="moderator",
                         to=settings.AUTH_USER_MODEL,
                     ),

--- a/myhpi/core/models.py
+++ b/myhpi/core/models.py
@@ -120,8 +120,8 @@ class MinutesForm(WagtailAdminPageForm):
 class Minutes(Page):
     group = ForeignKey(Group, on_delete=models.PROTECT, null=True)
     date = DateField()
-    moderator = ForeignKey(User, on_delete=models.CASCADE, related_name="moderator")
-    author = ForeignKey(User, on_delete=models.CASCADE, related_name="author")
+    moderator = ForeignKey(User, on_delete=models.PROTECT, related_name="moderator")
+    author = ForeignKey(User, on_delete=models.PROTECT, related_name="author")
     participants = ParentalManyToManyField(User, related_name="minutes")
     labels = ClusterTaggableManager(through=TaggedMinutes, blank=True)
     visible_for = ParentalManyToManyField(Group, related_name="visible_minutes")

--- a/myhpi/settings.py
+++ b/myhpi/settings.py
@@ -208,3 +208,5 @@ MESSAGE_TAGS = {
     constants.WARNING: "alert-warning",
     constants.ERROR: "alert-danger",
 }
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"


### PR DESCRIPTION
Closes #33 

Significant change: Users can not be deleted if they are referenced by minutes