### PR TITLE
Explicitly assign reviewer for dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-assign.yml
+++ b/.github/workflows/dependabot-assign.yml
@@ -9,5 +9,4 @@ jobs:
     steps:
       - uses: delivery-much/actions-assigner@v1
         with:
-          token: ${{ secrets.ADMIN_PAT }}
-          team-reviewers: myhpi-dependencies
+          reviewers: Paula-Kli


### PR DESCRIPTION
Since #106 didn't work with the reviewer team, as seen in #110, this should work (at least it has before).