### PR TITLE
Remove double entries in InformationPage

### DIFF
--- a/myhpi/core/models.py
+++ b/myhpi/core/models.py
@@ -55,17 +55,6 @@ class InformationPage(BasePage):
     def last_edited_by(self):
         return self.get_latest_revision().user
 
-    settings_panels = [
-        PublishingPanel(),
-        FieldPanel("is_public", widget=forms.CheckboxInput),
-        FieldPanel("visible_for", widget=forms.CheckboxSelectMultiple),
-        FieldPanel("author_visible", widget=forms.CheckboxInput(attrs={"checked": ""})),
-    ]
-
-    @property
-    def last_edited_by(self):
-        return self.get_latest_revision().user
-
 
 class MinutesList(BasePage):
     group = ForeignKey(Group, on_delete=models.PROTECT)


### PR DESCRIPTION
Probably introduced through a merge.