### PR TITLE
fix: Make menu scrollable on Desktop

### DIFF
--- a/myhpi/static/scss/navbar.scss
+++ b/myhpi/static/scss/navbar.scss
@@ -83,7 +83,7 @@
     #nav-item-container-root,
     #nav-level-right .nav-item-container {
         padding-left: 0;
-        max-height: 90vh;
+        max-height: 85vh;
     }
 
     #nav-item-container-root.show {
@@ -174,6 +174,8 @@
     }
 
     .navbar-bottom {
+        max-height: 70vh;
+        overflow-y: auto;
 
         .nav-level {
             width: 20rem;

--- a/myhpi/templates/base.html
+++ b/myhpi/templates/base.html
@@ -67,7 +67,7 @@
                 </div>
             </div>
         </div>
-        <div class="navbar-bottom d-flex overflow-hidden">
+        <div class="navbar-bottom d-flex">
             <div class="navbar-bottom-content page-content d-flex flex-column flex-xl-row flex-grow-1 flex-xl-grow-0">
                 {% build_nav_level nav_root_pages %}
 


### PR DESCRIPTION
Should be working now (testing it in depth is cumbersome for me, as I'd have to create loads of pages manually/duplicate nodes in DOM)