### PR TITLE
add Markdown preprocessor to decrease heading level

### DIFF
--- a/myhpi/core/markdown/extensions.py
+++ b/myhpi/core/markdown/extensions.py
@@ -133,6 +133,17 @@ class EnterLeavePreprocessor(MinutesBasePreprocessor):
         return self.enter_or_leavify(match, _("leaves"))
 
 
+class HeadingLevelPreprocessor(MinutesBasePreprocessor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.patterns = [
+            (r"^#{1,5}", self.decrease),
+        ]
+
+    def decrease(self, match):
+        return f"{match.group(0)}#"
+
+
 class InternalLinkPattern(LinkInlineProcessor):
     def handleMatch(self, m, data=None):
         el = markdown.util.etree.Element("a")
@@ -155,6 +166,7 @@ class MinuteExtension(Extension):
         md.preprocessors.register(BreakPreprocessor(md), "breakify", 200)
         md.preprocessors.register(QuorumPrepocessor(md), "quorumify", 200)
         md.preprocessors.register(EnterLeavePreprocessor(md), "enter_or_leavify", 200)
+        md.preprocessors.register(HeadingLevelPreprocessor(md), "decrease", 200)
         md.inlinePatterns.register(
             InternalLinkPattern(r"\[(?P<title>[^\[]+)\]\(page:(?P<id>\d+)\)", md),
             "InternalLinkPattern",


### PR DESCRIPTION
closes #45 

There is one small issue left with the current solution: a heading of level 6 is still matched by the regex, as there are 5 hashtags in it. This means that one is left with a result of `<h6># Text</h6>`. The smoother solution would be to not replace the line at all, but I can't come up with a regex that does so. As nobody actually uses h6 anyways, I think thats not such a big issue