### PR TITLE
Update poetry to version 1.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install poetry
-      run: curl -sSL https://install.python-poetry.org | python3 - --version 1.2.0
+      run: curl -sSL https://install.python-poetry.org | python3 - --version 1.3.2
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pypoetry/virtualenvs
@@ -72,7 +72,7 @@ jobs:
         #sudo apt-get install python-venv
         python -m venv env
         source env/bin/activate
-        curl -sSL https://install.python-poetry.org | python3 - --version 1.2.0
+        curl -sSL https://install.python-poetry.org | python3 - --version 1.3.2
     - name: Install dependencies
       # always install all -E extras to use a single cache
       run: |


### PR DESCRIPTION
Our pipeline currently fails as the lock files of version 1.3 of poetry are not compatible with the old logfiles [see changelog](https://github.com/python-poetry/poetry/blob/master/CHANGELOG.md) .