### PR TITLE
Move footer to end of (large) screens

### DIFF
--- a/myhpi/static/scss/myHPI.scss
+++ b/myhpi/static/scss/myHPI.scss
@@ -76,6 +76,16 @@ p {
     text-align: justify;
 }
 
+body {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+#page {
+    flex: 1 0 auto;
+}
+
 .page {
     margin: auto;
 }


### PR DESCRIPTION
Uses flexbox to move the footer to the end of the screen in cases where the content takes up less space than the screen is high.

I didn't talk to any contributor beforehand, so I'm not sure if you have any other plans, so feel free to just dismiss this PR if it doesnt fit :)

| Before | After |
| -- |-- |
|<img width="300" style="float: left" alt="image" src="https://user-images.githubusercontent.com/15076254/232605700-277af738-9daa-41f7-aace-b99340500820.png">|<img width="300" alt="image" style="float: right" src="https://user-images.githubusercontent.com/15076254/232605630-3becdc58-cf08-4790-9cc1-070dbab01dc8.png">|

_This pull request is brought to you by EvaP Hacking-Hours_