### PR TITLE
Sidebar improvements

### DIFF
--- a/myhpi/core/templates/core/information_page.html
+++ b/myhpi/core/templates/core/information_page.html
@@ -29,28 +29,7 @@
                     {{ page.last_edited_by }}
                 {% endif %}
             </aside>
-            {% if perms.wagtail.edit_page %}
-                <aside class="side-panel border-accent toc-container d-print-none">
-                    <h1 class="toc-title">{% translate "Visibility" %}</h1>
-                    {{ page.visible_for.all|join:", " }}
-                </aside>
-            {% endif %}
-            <aside class="side-panel border-accent toc-container d-print-none">
-                <h1 class="toc-title">{% translate "Table of contents" %}</h1>
-                {{ parsed_md.1 }}
-            </aside>
-            {% if page.attachments.all %}
-                <aside class="side-panel border-accent toc-container d-print-none">
-                    <h1 class="toc-title">{% translate "Attachments" %}</h1>
-                    <ul>
-                    {% for attachment in page.attachments.all %}
-                        <li>
-                            <a href="{{ attachment.url }}">{{ attachment.title }}</a>
-                        </li>
-                    {% endfor %}
-                    </ul>
-                </aside>
-            {% endif %}
+            {% include "core/sidebar.html" %}
         </div>
     </div>
 </div>

--- a/myhpi/core/templates/core/information_page.html
+++ b/myhpi/core/templates/core/information_page.html
@@ -17,7 +17,7 @@
     <div class="col-lg-3">
         <div class="side-panel-container">
             <aside class="side-panel border-accent">
-                <h1 class="toc-title">{% translate "Last edited" %}</h1>
+                <h1 class="side-panel-title">{% translate "Last edited" %}</h1>
                 {% if not page.last_published_at %}
                     {% translate "A long time ago" %}
                 {% else %}

--- a/myhpi/core/templates/core/information_page.html
+++ b/myhpi/core/templates/core/information_page.html
@@ -16,11 +16,6 @@
     </div>
     <div class="col-lg-3">
         <div class="side-panel-container">
-            {% if not page.live %}
-                <aside class="side-panel border-accent toc-container d-print-none">
-                    <h1 class="side-panel-warning">{% translate "⚠️ Preview ⚠️" %}</h1>
-                </aside>
-            {% endif %}
             <aside class="side-panel border-accent">
                 <h1 class="side-panel-title">{% translate "Last edited" %}</h1>
                 {% if not page.last_published_at %}

--- a/myhpi/core/templates/core/information_page.html
+++ b/myhpi/core/templates/core/information_page.html
@@ -29,6 +29,12 @@
                     {{ page.last_edited_by }}
                 {% endif %}
             </aside>
+            {% if perms.wagtail.edit_page %}
+                <aside class="side-panel border-accent toc-container d-print-none">
+                    <h1 class="toc-title">{% translate "Visibility" %}</h1>
+                    {{ page.visible_for.all|join:", " }}
+                </aside>
+            {% endif %}
             <aside class="side-panel border-accent toc-container d-print-none">
                 <h1 class="toc-title">{% translate "Table of contents" %}</h1>
                 {{ parsed_md.1 }}

--- a/myhpi/core/templates/core/information_page.html
+++ b/myhpi/core/templates/core/information_page.html
@@ -18,14 +18,18 @@
         <div class="side-panel-container">
             <aside class="side-panel border-accent">
                 <h1 class="toc-title">{% translate "Last edited" %}</h1>
-                {% get_current_timezone as TIMEZONE %}
-                <time id="last-published" datetime="{{ page.last_published_at|date:"c" }}" title="{{ TIMEZONE }}">
-                    {% blocktranslate with date=page.last_published_at|date:"SHORT_DATE_FORMAT" time=page.last_published_at|time:"TIME_FORMAT" trimmed %}
-                        {{ date }} at {{ time }}
-                    {% endblocktranslate %}
-                </time>
-                {% if page.author_visible %}
-                    {% translate "by" %}
+                {% if not page.last_published_at %}
+                    {% translate "A long time ago" %}
+                {% else %}
+                    {% get_current_timezone as TIMEZONE %}
+                    <time id="last-published" datetime="{{ page.last_published_at|date:"c" }}" title="{{ TIMEZONE }}">
+                        {% blocktranslate with date=page.last_published_at|date:"SHORT_DATE_FORMAT" time=page.last_published_at|time:"TIME_FORMAT" trimmed %}
+                            {{ date }} at {{ time }}
+                        {% endblocktranslate %}
+                    </time>
+                {% endif %}
+                {% if page.author_visible and page.last_edited_by %}
+                    <i>{% translate "by" %}</i>
                     {{ page.last_edited_by }}
                 {% endif %}
             </aside>

--- a/myhpi/core/templates/core/information_page.html
+++ b/myhpi/core/templates/core/information_page.html
@@ -16,6 +16,11 @@
     </div>
     <div class="col-lg-3">
         <div class="side-panel-container">
+            {% if not page.live %}
+                <aside class="side-panel border-accent toc-container d-print-none">
+                    <h1 class="side-panel-warning">{% translate "⚠️ Preview ⚠️" %}</h1>
+                </aside>
+            {% endif %}
             <aside class="side-panel border-accent">
                 <h1 class="side-panel-title">{% translate "Last edited" %}</h1>
                 {% if not page.last_published_at %}

--- a/myhpi/core/templates/core/minutes.html
+++ b/myhpi/core/templates/core/minutes.html
@@ -14,11 +14,6 @@
             {{ parsed_md.0 }}
         </div>
         <div class="col-3 minutes-meta">
-            {% if not page.live %}
-                <aside class="side-panel border-accent toc-container d-print-none">
-                    <h1 class="side-panel-warning">{% translate "⚠️ Preview ⚠️" %}</h1>
-                </aside>
-            {% endif %}
             <aside class="side-panel border-accent">
                 <h1 class="side-panel-title">{% translate "Date" %}</h1>
                 <p>{{ page.date }}</p>

--- a/myhpi/core/templates/core/minutes.html
+++ b/myhpi/core/templates/core/minutes.html
@@ -15,19 +15,19 @@
         </div>
         <div class="col-3 minutes-meta">
             <aside class="side-panel border-accent">
-                <h1 class="toc-title">{% translate "Date" %}</h1>
+                <h1 class="side-panel-title">{% translate "Date" %}</h1>
                 <p>{{ page.date }}</p>
             </aside>
             <aside class="side-panel border-accent">
-                <h1 class="toc-title">{% translate "Moderator" %}</h1>
+                <h1 class="side-panel-title">{% translate "Moderator" %}</h1>
                 <p>{{ page.moderator.get_full_name }}</p>
             </aside>
             <aside class="side-panel border-accent">
-                <h1 class="toc-title">{% translate "Minutes taker" %}</h1>
+                <h1 class="side-panel-title">{% translate "Minutes taker" %}</h1>
                 <p>{{ page.author.get_full_name }}</p>
             </aside>
             <aside class="side-panel border-accent">
-                <h1 class="toc-title">{% translate "Participants" %}</h1>
+                <h1 class="side-panel-title">{% translate "Participants" %}</h1>
                 <ul>
                     {% for participant in page.participants.all %}
                         <li>{{ participant.get_full_name }}</li>
@@ -35,7 +35,7 @@
                 </ul>
             </aside>
             <aside class="side-panel border-accent">
-                <h1 class="toc-title">{% translate "Guests" %}</h1>
+                <h1 class="side-panel-title">{% translate "Guests" %}</h1>
                 {% if page.guests %}
                     <ul>
                     {% for guest in page.guests %}
@@ -47,7 +47,7 @@
                 {% endif %}
             </aside>
             <aside class="side-panel border-accent">
-                <h1 class="toc-title">{% translate "Labels" %}</h1>
+                <h1 class="side-panel-title">{% translate "Labels" %}</h1>
                 {%  if page.labels.all %}
                     <p>{% include "core/label.html" with minutes=page %}</p>
                 {% else %}

--- a/myhpi/core/templates/core/minutes.html
+++ b/myhpi/core/templates/core/minutes.html
@@ -8,69 +8,69 @@
     <div class="row minutes-container">
         {% with page.body|markdown as parsed_md %}
         <div class="d-none d-print-block minutes-title">
-        <h1>{{  page.title }}</h1>
+            <h1>{{  page.title }}</h1>
         </div>
         <div class="col-9 minutes-text">
             {{ parsed_md.0 }}
         </div>
         <div class="col-3 minutes-meta">
-            <h4>{% translate "Date" %}</h4>
-            <p>{{ page.date }}</p>
-            <h4>{% translate "Moderator" %}</h4>
-            <p>{{ page.moderator.get_full_name }}</p>
-            <h4>{% translate "Minutes taker" %}</h4>
-            <p>{{ page.author.get_full_name }}</p>
-            <h4>{% translate "Participants" %}</h4>
-            <ul>
-                {% for participant in page.participants.all %}
-                    <li>{{ participant.get_full_name }}</li>
-                {% endfor %}
-            </ul>
-            <h4>{% translate "Guests" %}</h4>
-            {% if page.guests %}
+            <aside class="side-panel border-accent">
+                <h1 class="toc-title">{% translate "Date" %}</h1>
+                <p>{{ page.date }}</p>
+            </aside>
+            <aside class="side-panel border-accent">
+                <h1 class="toc-title">{% translate "Moderator" %}</h1>
+                <p>{{ page.moderator.get_full_name }}</p>
+            </aside>
+            <aside class="side-panel border-accent">
+                <h1 class="toc-title">{% translate "Minutes taker" %}</h1>
+                <p>{{ page.author.get_full_name }}</p>
+            </aside>
+            <aside class="side-panel border-accent">
+                <h1 class="toc-title">{% translate "Participants" %}</h1>
                 <ul>
-                {% for guest in page.guests %}
-                    <li>{{ guest }}</li>
-                {% endfor %}
+                    {% for participant in page.participants.all %}
+                        <li>{{ participant.get_full_name }}</li>
+                    {% endfor %}
                 </ul>
-            {% else %}
-                <i>{% translate "No guests" %}</i>
-            {% endif %}
-            <h4>{% translate "Labels" %}</h4>
+            </aside>
+            <aside class="side-panel border-accent">
+                <h1 class="toc-title">{% translate "Guests" %}</h1>
+                {% if page.guests %}
+                    <ul>
+                    {% for guest in page.guests %}
+                        <li>{{ guest }}</li>
+                    {% endfor %}
+                    </ul>
+                {% else %}
+                    <i>{% translate "No guests" %}</i>
+                {% endif %}
+            </aside>
+            <aside class="side-panel border-accent">
+                <h1 class="toc-title">{% translate "Labels" %}</h1>
                 {%  if page.labels.all %}
-                    <p>
-                    {% include "core/label.html" with minutes=page %}
-                    </p>
-                    {% else %}
+                    <p>{% include "core/label.html" with minutes=page %}</p>
+                {% else %}
                     <i>{% translate "No labels"%}</i>
                 {% endif %}
-            <h4 class="d-print-none">{% translate "Table of contents" %}</h4>
-            {{ parsed_md.1 }}
-            {% if page.attachments.all %}
-                <h4 class="d-print-none">{% translate "Attachments" %}</h4>
-                <ul>
-                {% for attachment in page.attachments.all %}
-                    <li>
-                        <a href="{{ attachment.url }}">{{ attachment.title }}</a>
-                    </li>
-                {% endfor %}
-                </ul>
-            {% endif %}
+            </aside>
+            {% include "core/sidebar.html" %}
         </div>
         <div id="minutes-footer" class="d-none d-print-block"></div>
-            <div id="minutes-navigation" class="row d-print-none">
-                <div class="col-6">
-                    {%  prev_minutes page as prev %}
-                    {% if prev %}
-                        <a href="{{ prev.url }}">< {% translate "Previous minutes" %}</a>
-                    {%  endif %}
-                </div>
-                <div class="col-6">
-                    {%  next_minutes page as next %}
-                    {% if next %}
-                        <a href="{{ next.url }}"> {% translate "Next minutes" %} ></a>
-                    {%  endif %}
-                </div>
+        <div id="minutes-navigation" class="row d-print-none">
+            <div class="col-6">
+                {%  prev_minutes page as prev %}
+                {% if prev %}
+                    <a href="{{ prev.url }}">< {% translate "Previous minutes" %}</a>
+                {%  endif %}
+            </div>
+            <div class="col-6">
+                {%  next_minutes page as next %}
+                {% if next %}
+                    <a href="{{ next.url }}"> {% translate "Next minutes" %} ></a>
+                {%  endif %}
+            </div>
+        </div>
         {% endwith %}
     </div>
 {% endblock %}

--- a/myhpi/core/templates/core/minutes.html
+++ b/myhpi/core/templates/core/minutes.html
@@ -14,6 +14,11 @@
             {{ parsed_md.0 }}
         </div>
         <div class="col-3 minutes-meta">
+            {% if not page.live %}
+                <aside class="side-panel border-accent toc-container d-print-none">
+                    <h1 class="side-panel-warning">{% translate "⚠️ Preview ⚠️" %}</h1>
+                </aside>
+            {% endif %}
             <aside class="side-panel border-accent">
                 <h1 class="side-panel-title">{% translate "Date" %}</h1>
                 <p>{{ page.date }}</p>

--- a/myhpi/core/templates/core/minutes_list.html
+++ b/myhpi/core/templates/core/minutes_list.html
@@ -11,8 +11,8 @@
             <tr>
                 <td><a href="{{ minute.get_valid_url }}">{{ minute.date|date:"d.m.Y" }}</a></td>
                 <td>
-                    {% if not minute.live %}
-                        <span title={% translate "Draft" %} aria-hidden="true">⚠️</span>
+                    {% if minute.has_unpublished_changes %}
+                        <span title='{% translate "Page has unpublished changes!" %}' aria-hidden="true">⚠️</span>
                     {% endif %}
                 </td>
                 <td>

--- a/myhpi/core/templates/core/sidebar.html
+++ b/myhpi/core/templates/core/sidebar.html
@@ -1,12 +1,12 @@
 {% load core_extras %}
 {% load i18n %}
 
-{% if not page.live %}
-<aside class="side-panel border-accent toc-container d-print-none">
-    <h1 class="side-panel-warning">{% translate "⚠️ Preview ⚠️" %}</h1>
-</aside>
-{% endif %}
 {% if perms.wagtail.edit_page %}
+    {% if page.has_unpublished_changes %}
+    <aside class="side-panel border-accent toc-container d-print-none">
+        <h1 class="side-panel-warning">{% translate "Page has unpublished changes!" %}</h1>
+    </aside>
+    {% endif %}
     <aside class="side-panel border-accent toc-container d-print-none">
         <h1 class="side-panel-title">{% translate "Visibility" %}</h1>
         {{ page.visible_for.all|join:", " }}

--- a/myhpi/core/templates/core/sidebar.html
+++ b/myhpi/core/templates/core/sidebar.html
@@ -1,0 +1,25 @@
+{% load core_extras %}
+{% load i18n %}
+
+{% if perms.wagtail.edit_page %}
+    <aside class="side-panel border-accent toc-container d-print-none">
+        <h1 class="toc-title">{% translate "Visibility" %}</h1>
+        {{ page.visible_for.all|join:", " }}
+    </aside>
+{% endif %}
+<aside class="side-panel border-accent toc-container d-print-none">
+    <h1 class="toc-title">{% translate "Table of contents" %}</h1>
+    {{ parsed_md.1 }}
+</aside>
+{% if page.attachments.all %}
+    <aside class="side-panel border-accent toc-container d-print-none">
+        <h1 class="toc-title">{% translate "Attachments" %}</h1>
+        <ul>
+        {% for attachment in page.attachments.all %}
+            <li>
+                <a href="{{ attachment.url }}">{{ attachment.title }}</a>
+            </li>
+        {% endfor %}
+        </ul>
+    </aside>
+{% endif %}

--- a/myhpi/core/templates/core/sidebar.html
+++ b/myhpi/core/templates/core/sidebar.html
@@ -1,6 +1,11 @@
 {% load core_extras %}
 {% load i18n %}
 
+{% if not page.live %}
+<aside class="side-panel border-accent toc-container d-print-none">
+    <h1 class="side-panel-warning">{% translate "⚠️ Preview ⚠️" %}</h1>
+</aside>
+{% endif %}
 {% if perms.wagtail.edit_page %}
     <aside class="side-panel border-accent toc-container d-print-none">
         <h1 class="side-panel-title">{% translate "Visibility" %}</h1>

--- a/myhpi/core/templates/core/sidebar.html
+++ b/myhpi/core/templates/core/sidebar.html
@@ -3,17 +3,17 @@
 
 {% if perms.wagtail.edit_page %}
     <aside class="side-panel border-accent toc-container d-print-none">
-        <h1 class="toc-title">{% translate "Visibility" %}</h1>
+        <h1 class="side-panel-title">{% translate "Visibility" %}</h1>
         {{ page.visible_for.all|join:", " }}
     </aside>
 {% endif %}
 <aside class="side-panel border-accent toc-container d-print-none">
-    <h1 class="toc-title">{% translate "Table of contents" %}</h1>
+    <h1 class="side-panel-title">{% translate "Table of contents" %}</h1>
     {{ parsed_md.1 }}
 </aside>
 {% if page.attachments.all %}
     <aside class="side-panel border-accent toc-container d-print-none">
-        <h1 class="toc-title">{% translate "Attachments" %}</h1>
+        <h1 class="side-panel-title">{% translate "Attachments" %}</h1>
         <ul>
         {% for attachment in page.attachments.all %}
             <li>

--- a/myhpi/locale/de/LC_MESSAGES/django.po
+++ b/myhpi/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-12 19:24+0100\n"
+"POT-Creation-Date: 2023-12-20 18:27+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -75,6 +75,10 @@ msgstr "Zuletzt bearbeitet"
 msgid "%(date)s at %(time)s"
 msgstr "%(date)s um %(time)s Uhr"
 
+#: core/templates/core/information_page.html:21
+msgid "A long time ago"
+msgstr "Vor langer Zeit"
+
 #: core/templates/core/information_page.html:28
 msgid "by"
 msgstr "von"
@@ -93,45 +97,61 @@ msgstr "Anhänge"
 msgid "Date"
 msgstr "Datum"
 
-#: core/templates/core/minutes.html:19
+#: core/templates/core/minutes.html:22
 msgid "Moderator"
 msgstr "Sitzungsleitung"
 
-#: core/templates/core/minutes.html:21
+#: core/templates/core/minutes.html:26
 msgid "Minutes taker"
 msgstr "Protokollführung"
 
-#: core/templates/core/minutes.html:23
+#: core/templates/core/minutes.html:30
 msgid "Participants"
 msgstr "Teilnehmende"
 
-#: core/templates/core/minutes.html:29
+#: core/templates/core/minutes.html:38
 msgid "Guests"
 msgstr "Gäste"
 
-#: core/templates/core/minutes.html:37
+#: core/templates/core/minutes.html:46
 msgid "No guests"
 msgstr "Keine Gäste"
 
-#: core/templates/core/minutes.html:39
+#: core/templates/core/minutes.html:50
 msgid "Labels"
 msgstr "Labels"
 
-#: core/templates/core/minutes.html:45
+#: core/templates/core/minutes.html:54
 msgid "No labels"
 msgstr "Keine Labels"
 
-#: core/templates/core/minutes.html:65
+#: core/templates/core/minutes.html:64
 msgid "Previous minutes"
 msgstr "Vorheriges Protokoll"
 
-#: core/templates/core/minutes.html:71
+#: core/templates/core/minutes.html:70
 msgid "Next minutes"
 msgstr "Nächstes Protokoll"
 
 #: core/templates/core/minutes_list.html:15
 msgid "Draft"
 msgstr "Entwurf"
+
+#: core/templates/core/sidebar.html:6
+msgid "⚠️ Preview ⚠️"
+msgstr "⚠️ Vorschau ⚠️"
+
+#: core/templates/core/sidebar.html:11
+msgid "Visibility"
+msgstr "Sichtbarkeit"
+
+#: core/templates/core/sidebar.html:16 polls/templates/polls/poll.html:29
+msgid "Table of contents"
+msgstr "Inhaltsverzeichnis"
+
+#: core/templates/core/sidebar.html:21
+msgid "Attachments"
+msgstr "Anhänge"
 
 #: polls/templates/polls/poll.html:17
 msgid "You have already voted and the results are not yet visible."

--- a/myhpi/locale/de/LC_MESSAGES/django.po
+++ b/myhpi/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-20 18:27+0100\n"
+"POT-Creation-Date: 2024-01-25 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -137,9 +137,9 @@ msgstr "Nächstes Protokoll"
 msgid "Draft"
 msgstr "Entwurf"
 
-#: core/templates/core/sidebar.html:6
-msgid "⚠️ Preview ⚠️"
-msgstr "⚠️ Vorschau ⚠️"
+#: core/templates/core/sidebar.html:7
+msgid "Page has unpublished changes!"
+msgstr "Seite hat unveröffentlichte Änderungen!"
 
 #: core/templates/core/sidebar.html:11
 msgid "Visibility"

--- a/myhpi/locale/de/LC_MESSAGES/django.po
+++ b/myhpi/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-25 15:21+0000\n"
+"POT-Creation-Date: 2024-02-13 11:43+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,51 +18,51 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: core/markdown/extensions.py:53
+#: core/markdown/extensions.py:56
 msgid "Begin of meeting"
 msgstr "Beginn des Meetings"
 
-#: core/markdown/extensions.py:56
+#: core/markdown/extensions.py:59
 msgid "End of meeting"
 msgstr "Ende des Meetings"
 
-#: core/markdown/extensions.py:70
+#: core/markdown/extensions.py:73
 #, python-brace-format
 msgid "*Meeting break: {time_start_break} – {time_end_break}*"
 msgstr "*Sitzungspause: {time_start_break} – {time_end_break}*"
 
-#: core/markdown/extensions.py:87
+#: core/markdown/extensions.py:90
 msgid "quorate"
 msgstr "beschlussfähig"
 
-#: core/markdown/extensions.py:87
+#: core/markdown/extensions.py:90
 msgid "not quorate"
 msgstr "nicht beschlussfähig"
 
-#: core/markdown/extensions.py:90
+#: core/markdown/extensions.py:93
 #, python-brace-format
 msgid "*{num_participants}/{max_num_participants} present → {quorate}*  "
 msgstr "*{num_participants}/{max_num_participants} anwesend → {quorate}*  "
 
-#: core/markdown/extensions.py:114
+#: core/markdown/extensions.py:117
 #, python-brace-format
 msgid "*{time}: {name} {event} the meeting*  "
 msgstr "*{time}: {name} {event} das Meeting*  "
 
-#: core/markdown/extensions.py:119
+#: core/markdown/extensions.py:122
 #, python-brace-format
 msgid "*{time}: {name} {event} the meeting via {mean_of_participation}*  "
 msgstr "*{time}: {name} {event} das Meeting via {mean_of_participation}*  "
 
-#: core/markdown/extensions.py:129
+#: core/markdown/extensions.py:132
 msgid "enters"
 msgstr "betritt"
 
-#: core/markdown/extensions.py:132
+#: core/markdown/extensions.py:135
 msgid "leaves"
 msgstr "verlässt"
 
-#: core/markdown/extensions.py:153
+#: core/markdown/extensions.py:156
 msgid "[missing link]"
 msgstr "[link fehlt]"
 
@@ -70,30 +70,20 @@ msgstr "[link fehlt]"
 msgid "Last edited"
 msgstr "Zuletzt bearbeitet"
 
-#: core/templates/core/information_page.html:23
+#: core/templates/core/information_page.html:22
+msgid "A long time ago"
+msgstr "Vor langer Zeit"
+
+#: core/templates/core/information_page.html:26
 #, python-format
 msgid "%(date)s at %(time)s"
 msgstr "%(date)s um %(time)s Uhr"
 
-#: core/templates/core/information_page.html:21
-msgid "A long time ago"
-msgstr "Vor langer Zeit"
-
-#: core/templates/core/information_page.html:28
+#: core/templates/core/information_page.html:32
 msgid "by"
 msgstr "von"
 
-#: core/templates/core/information_page.html:33
-#: core/templates/core/minutes.html:47 polls/templates/polls/poll.html:29
-msgid "Table of contents"
-msgstr "Inhaltsverzeichnis"
-
-#: core/templates/core/information_page.html:38
-#: core/templates/core/minutes.html:50
-msgid "Attachments"
-msgstr "Anhänge"
-
-#: core/templates/core/minutes.html:17
+#: core/templates/core/minutes.html:18
 msgid "Date"
 msgstr "Datum"
 
@@ -133,11 +123,7 @@ msgstr "Vorheriges Protokoll"
 msgid "Next minutes"
 msgstr "Nächstes Protokoll"
 
-#: core/templates/core/minutes_list.html:15
-msgid "Draft"
-msgstr "Entwurf"
-
-#: core/templates/core/sidebar.html:7
+#: core/templates/core/minutes_list.html:15 core/templates/core/sidebar.html:7
 msgid "Page has unpublished changes!"
 msgstr "Seite hat unveröffentlichte Änderungen!"
 
@@ -528,6 +514,9 @@ msgstr "{email} hat erfolgreich {list} verlassen."
 #, python-brace-format
 msgid "The subscription of {email} onto {list} was rolled back."
 msgstr "Die Anmeldung von {email} auf {list} wurde rückgänig gemacht."
+
+#~ msgid "Draft"
+#~ msgstr "Entwurf"
 
 #, fuzzy
 #~| msgid "[missing link]"

--- a/myhpi/static/scss/myHPI.scss
+++ b/myhpi/static/scss/myHPI.scss
@@ -144,6 +144,17 @@ p {
     border-top: solid 2px var(--bs-border);
 }
 
+.side-panel-title {
+    font-size: 1.05rem;
+    line-height: 1.1;
+    font-weight: 600;
+}
+
+h1.side-panel-title::after {
+    margin: 0;
+    height: 0px;
+}
+
 .toc-container ul {
     list-style: none;
     padding: 0;
@@ -151,17 +162,6 @@ p {
 
 .toc-container ul li>ul {
     margin-left: 0.5rem;
-}
-
-.toc-title {
-    font-size: 1.05rem;
-    line-height: 1.1;
-    font-weight: 600;
-}
-
-h1.toc-title::after {
-    margin: 0;
-    height: 0px;
 }
 
 .search-result-list {

--- a/myhpi/static/scss/myHPI.scss
+++ b/myhpi/static/scss/myHPI.scss
@@ -155,6 +155,17 @@ h1.side-panel-title::after {
     height: 0px;
 }
 
+.side-panel-warning {
+    background-color: #ff000011;
+    border: 2px solid red;
+    text-align: center;
+    border-radius: 5px;
+    padding: 10px;
+    font-size: 1.05rem;
+    line-height: 1.1;
+    font-weight: 600;
+}
+
 .toc-container ul {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
Closes #353.

Furthermore, this PR streamlines the minute and information page sidebar layout (see second commit) and also adds empty date or editor handling.

**I was unable to test some of the changes, specifically those about the minute sidebar. Before approving, please check whether everything looks as expected.** I'm investigating why minute pages don't work (even on main) on my local setup.