### PR TITLE
Add style to minutes participant selection

### DIFF
--- a/myhpi/core/models.py
+++ b/myhpi/core/models.py
@@ -195,7 +195,7 @@ class Minutes(BasePage):
         FieldPanel("date"),
         FieldPanel("moderator"),
         FieldPanel("author"),
-        FieldPanel("participants", widget=UserSelectWidget),
+        FieldPanel("participants", widget=UserSelectWidget({'data-width': '10%'})),
         FieldPanel("labels"),
         FieldPanel("body"),
         FieldPanel("guests"),


### PR DESCRIPTION
On my machine fixes the error that I found when no participants in a minute are preselected
[Here](https://select2.org/appearance#container-width) I found more options in case we want to fix that in a global stylesheet.

![image](https://github.com/fsr-de/myHPI/assets/49535291/8699c547-4bc0-42b3-996c-c0fe804a113e)
