### PR TITLE
Hotfix: Update username to be able to log in a second time

### DIFF
--- a/myhpi/core/auth.py
+++ b/myhpi/core/auth.py
@@ -31,6 +31,7 @@ class MyHPIOIDCAB(OIDCAuthenticationBackend):
         return user
 
     def update_user(self, user, claims):
+        user.username = claims.get("sub")
         user.email = claims.get("email")
         user.first_name = claims.get("given_name", "")
         user.last_name = claims.get("family_name", "")


### PR DESCRIPTION
Due to the migration, the claims contain changed usernames and email addresses. However, only the new email address was preserved.
Therefore, the account was not found during a second log in.