### PR TITLE
Sort menu items in frontend

### DIFF
--- a/myhpi/core/context.py
+++ b/myhpi/core/context.py
@@ -33,7 +33,7 @@ def base_context(request):
 
     minutes_creation_links = {}
     for group in request.user.groups.all():
-        minutes_creation_links[group.id] = create_minutes_for_group_link(request.user, group)
+        minutes_creation_links[group.id] = create_minutes_for_group_link(request.user, group).order_by('path')
 
     return {
         "root_page": root_page,

--- a/myhpi/core/context.py
+++ b/myhpi/core/context.py
@@ -29,7 +29,7 @@ def base_context(request):
     page_lookup = {}
 
     for page in pages_visible_for_user:
-        page_lookup[page.path] = pages_visible_for_user.child_of(page).order_by('path')
+        page_lookup[page.path] = pages_visible_for_user.child_of(page).order_by("path")
 
     minutes_creation_links = {}
     for group in request.user.groups.all():

--- a/myhpi/core/context.py
+++ b/myhpi/core/context.py
@@ -29,11 +29,11 @@ def base_context(request):
     page_lookup = {}
 
     for page in pages_visible_for_user:
-        page_lookup[page.path] = pages_visible_for_user.child_of(page)
+        page_lookup[page.path] = pages_visible_for_user.child_of(page).order_by('path')
 
     minutes_creation_links = {}
     for group in request.user.groups.all():
-        minutes_creation_links[group.id] = create_minutes_for_group_link(request.user, group).order_by('path')
+        minutes_creation_links[group.id] = create_minutes_for_group_link(request.user, group)
 
     return {
         "root_page": root_page,


### PR DESCRIPTION
Closes #429 

This PR sorts the menus based on the `path` attribute of each page which represents the configured ordering in the admin interface. 