### PR TITLE
Fix abbreviation rendering with table at the end

### DIFF
--- a/myhpi/core/markdown/utils.py
+++ b/myhpi/core/markdown/utils.py
@@ -25,7 +25,7 @@ def _transform_markdown_into_html(text, with_abbreveations):
         MinuteExtension()
     )  # should be in settings.py, but module lookup doesn't work
     md = markdown.Markdown(**markdown_kwargs)
-    abbreveations = "\n" + (
+    abbreveations = "\n\n" + (
         "\n".join(
             [
                 f"*[{abbr.abbreviation}]: {abbr.explanation}"


### PR DESCRIPTION
Closes #458

Trailing newlines are stripped from the markdown, thus needing two `\n` before appending the abbreviations.