### PR TITLE
Fetch tags to use dynamic versioning

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout # Checkout the repository to allow for dynamic versioning
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
Once again for dynamic versioning. The current image has the version 0.0.0 because tags are not fetched when checking out. That should be solved with this PR.