### PR TITLE
Fetch entire history in docker action

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout # Checkout the repository to allow for dynamic versioning
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
Sadly #473 still did not fetch the tags, which I verified when I downloaded the image. This will fetch the entire commit history. We can see afterward if it works and slows down the action significantly.