### PR TITLE
Fully enable Keycloak Group management

### DIFF
--- a/myhpi/core/auth.py
+++ b/myhpi/core/auth.py
@@ -35,8 +35,7 @@ class MyHPIOIDCAB(OIDCAuthenticationBackend):
         user.email = claims.get("email")
         user.first_name = claims.get("given_name", "")
         user.last_name = claims.get("family_name", "")
-        # group updating currently disabled until all groups are migrated to keycloak
-        # self._update_groups(user, claims)
+        self._update_groups(user, claims)
         user.save()
 
         return user


### PR DESCRIPTION
The previous PR #422 prepared everything for the migration to Keycloak and used it as the IDP. 

As we have now migrated our group memberships to Keycloak, we can now update the myHPI groups from the data given in the OIDC tokens. 

This PR effectively only re-enables a disabled line of code. We have tested its functionality using a hotpatch in the production environment. 