### PR TITLE
Make all `ParentalManyToManyFields` synchronized

### DIFF
--- a/myhpi/core/models.py
+++ b/myhpi/core/models.py
@@ -17,6 +17,7 @@ from wagtail.documents.models import Document
 from wagtail.models import Page, Site
 from wagtail.search import index
 from wagtail.snippets.models import register_snippet
+from wagtail_localize.fields import SynchronizedField
 
 from myhpi.core.markdown.fields import CustomMarkdownField
 from myhpi.core.utils import get_user_groups
@@ -28,6 +29,9 @@ class BasePage(Page):
     is_public = BooleanField()
     is_creatable = False
 
+    override_translatable_fields = [
+        SynchronizedField("visible_for"),
+    ]
     settings_panels = [
         PublishingPanel(),
         FieldPanel("is_public", widget=forms.CheckboxInput),
@@ -54,6 +58,9 @@ class InformationPage(BasePage):
     author_visible = BooleanField()
     attachments = ParentalManyToManyField(Document, blank=True)
 
+    override_translatable_fields = [
+        SynchronizedField("attachments"),
+    ]
     content_panels = Page.content_panels + [
         FieldPanel("body", classname="full"),
         FieldPanel("attachments", widget=AttachmentSelectWidget),
@@ -211,6 +218,10 @@ class Minutes(BasePage):
     guests = models.JSONField(blank=True, default=[])
     attachments = ParentalManyToManyField(Document, blank=True)
 
+    override_translatable_fields = [
+        SynchronizedField("participants"),
+        SynchronizedField("attachments"),
+    ]
     content_panels = Page.content_panels + [
         FieldPanel("date"),
         FieldPanel("moderator", widget=UserSelectWidget({"data-width": "100%"})),


### PR DESCRIPTION
When changing the value of these fields on a German page and synchronizing the translation, the change will be applied to the translation, too.

Closes #373 