### PR TITLE
Match HTML lang to user preference

### DIFF
--- a/myhpi/templates/base.html
+++ b/myhpi/templates/base.html
@@ -8,7 +8,8 @@
 {% load cache %}
 
 <!DOCTYPE html>
-<html lang="en">
+{% get_current_language as LANGUAGE_CODE %}
+<html lang="{{ LANGUAGE_CODE }}">
 
 <head>
     <meta charset="utf-8" />
@@ -81,7 +82,6 @@
         <div class="navbar-bottom d-flex">
             <div class="navbar-bottom-content page-content d-flex flex-column flex-xl-row flex-grow-1 flex-xl-grow-0">
 
-                {% get_current_language as LANGUAGE_CODE %}
                 {% cache 500 menu request.user.id request.user.ip_range_group_name LANGUAGE_CODE %}
                     {% build_nav_level_for root_page %}
                 {% endcache %}


### PR DESCRIPTION
Requesting the German version `/de` now sets the `<html lang="de">` language. Closes #494