### PR TITLE
Work around missing image class in translations bug

### DIFF
--- a/myhpi/static/scss/myHPI.scss
+++ b/myhpi/static/scss/myHPI.scss
@@ -218,7 +218,7 @@ h1.side-panel-title::after {
     margin-top: -0.25rem;
 }
 
-.rendered-image {
+img {
     max-width: 100%;
 }
 


### PR DESCRIPTION
Closes #483.

---
Further explanations:

- Relevant code is in myhpi/core/markdown/fields.py
- Specifically: `html2text` drops all css classes when converting html back to md
- Sadly, there is no quick workaround to get those classes back