### PR TITLE
Only access parent page if defined

### DIFF
--- a/myhpi/core/models.py
+++ b/myhpi/core/models.py
@@ -152,9 +152,9 @@ class MinutesForm(WagtailAdminPageForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.minutes_list = kwargs["parent_page"]
-
         if not kwargs["instance"].title:  # Check if page has been created
+            self.minutes_list = kwargs["parent_page"]
+
             self.initial["date"] = date.today()
             self.initial["slug"] = date.today().isoformat()
 


### PR DESCRIPTION
`parent_page` is not defined when older revisions are viewed. As we only have to access it for newly created minutes, the access can be moved into the body of the if statement.