### PR TITLE
Enforce german locale for time strings in markdown

### DIFF
--- a/myhpi/static/js/admin/easymde_custom.js
+++ b/myhpi/static/js/admin/easymde_custom.js
@@ -86,7 +86,7 @@ window.wagtailMarkdown.options = {
 
 // convenience function
 function getCurrentTime(){
-    return new Date().toLocaleTimeString([], {timeStyle: 'short'})
+    return new Date().toLocaleTimeString("de-DE", {timeStyle: 'short'})
 }
 
 // Custom button actions


### PR DESCRIPTION
Our custom markdown extensions only recognize time strings in German locale. Therefore, this PR enforces German locale for timestamps added to minutes by the buttons in the editor.

Closes #359 