### PR TITLE
Don't wrap lines when converting HTML back to MD

### DIFF
--- a/myhpi/core/markdown/fields.py
+++ b/myhpi/core/markdown/fields.py
@@ -30,4 +30,4 @@ class CustomMarkdownField(MarkdownField):
 
     def restore_translated_segments(self, value, field_segments):
         format, template, strings = organise_template_segments(field_segments)
-        return html2text.html2text(restore_strings(template, strings))
+        return html2text.html2text(restore_strings(template, strings), bodywidth=0)


### PR DESCRIPTION
Set maximum line length to 0 so headings won't be truncated.

Closes #510 