### PR TITLE
feature(minutes): add year-based pagination

### DIFF
--- a/myhpi/core/models.py
+++ b/myhpi/core/models.py
@@ -119,28 +119,39 @@ class MinutesList(BasePage):
 
     def get_visible_minutes(self, request):
         user_groups = get_user_groups(request.user)
-        minutes_ids = self.get_children().exact_type(Minutes).values_list("id", flat=True)
+        minutes = Minutes.objects.child_of(self)
 
+        visible_minutes = minutes.filter(Q(visible_for__in=user_groups) | Q(is_public=True))
         # display all minutes including drafts if user is in group that owns the minutes list
         if self.group in user_groups:
-            return Minutes.objects.filter(id__in=minutes_ids).order_by("-date")
+            visible_minutes = minutes
+        return visible_minutes
 
-        minutes_list = (
-            Minutes.objects.filter(id__in=minutes_ids)
-            .filter(Q(visible_for__in=user_groups) | Q(is_public=True))
-            .order_by("-date")
-            .distinct()
-        )
-        return minutes_list
+    def get_visible_minutes_for_year(self, request):
+        visible_minutes = self.get_visible_minutes(request)
+        try:
+            year = request.GET.get("year", None)
+            if year is None:
+                year = visible_minutes.order_by("-date")[0].date.year
+            else:
+                year = int(year)
+        except (ValueError, IndexError):
+            year = date.today().year
+        year_list = list(map(lambda d: d.year, visible_minutes.dates("date", "year")))
+
+        minutes = visible_minutes.filter(date__year=year).order_by("-date").distinct()
+        return year, year_list, minutes
 
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
-        minutes_list = self.get_visible_minutes(request)
-        context.setdefault("minutes_list", minutes_list)
-        minutes_by_years = defaultdict(lambda: [])
-        for minute in minutes_list:
-            minutes_by_years[minute.date.year].append(minute)
-        context["minutes_by_years"] = dict(minutes_by_years)
+        selected_year, all_years, minutes = self.get_visible_minutes_for_year(request)
+        context["selected_year"], context["all_years"] = selected_year, all_years
+        try:
+            year_index = all_years.index(selected_year)
+            context["year_range"] = all_years[max(year_index - 3, 0) : year_index + 4]
+        except ValueError:
+            context["year_range"] = all_years[-3:]
+        context["minutes"], context["minutes_list"] = minutes, self
         return context
 
 

--- a/myhpi/core/templates/core/minutes_list.html
+++ b/myhpi/core/templates/core/minutes_list.html
@@ -3,10 +3,9 @@
 {% load i18n %}
 
 {% block content %}
-<h1>{{ page.title }}</h1>
-    {% for year,minutes in minutes_by_years.items %}
-        <h3 id="year{{ year }}">{{ year }}</h3>
-        <table class="table table-striped">
+<h1>{{ page.title }} {{ selected_year }}</h1>
+{% if minutes %}
+    <table class="table table-striped">
         {% for minute in minutes %}
             <tr>
                 <td><a href="{{ minute.get_valid_url }}">{{ minute.date|date:"d.m.Y" }}</a></td>
@@ -28,6 +27,56 @@
                 </td>
             </tr>
         {% endfor %}
-        </table>
-    {% endfor %}
+    </table>
+{% else %}
+    <p>
+        {% translate "No minutes available for this year." %}
+    </p>
+{% endif %}
+{% if all_years|length > 1 %}
+<nav aria-label="Page navigation" class="d-inline-block">
+    <ul class="pagination">
+        <li class="page-item {% if selected_year == all_years|first %} disabled {% endif %}">
+            <a class="page-link" href="{{ minute_list.get_valid_url }}?year={{ all_years|first }}" aria-label="First">
+                <span aria-hidden="true">&laquo;</span>
+            </a>
+        </li>
+
+        {% if all_years|first != year_range|first %}
+        <li class="page-item disabled">
+            <a class="page-link" aria-label="More">
+                <span aria-hidden="true">...</span>
+            </a>
+        </li>
+        {% endif %}
+
+        {% for paginated_year in year_range %}
+        <li
+            {% if selected_year == paginated_year %}
+            class="page-item active" aria-current="true"
+            {% else %}
+            class="page-item"
+            {% endif %}>
+            <a class="page-link" href="{{ minute_list.get_valid_url }}?year={{ paginated_year }}">
+                {{ paginated_year }}
+            </a>
+        </li>
+        {% endfor %}
+
+        {% if all_years|last != year_range|last %}
+        <li class="page-item disabled">
+            <a class="page-link" aria-label="More">
+                <span aria-hidden="true">...</span>
+            </a>
+        </li>
+        {% endif %}
+
+        <li class="page-item {% if selected_year == all_years|last %} disabled {% endif %}">
+            <a class="page-link" href="{{ minute_list.get_valid_url }}?year={{ all_years|last }}" aria-label="Last">
+                <span aria-hidden="true">&raquo;</span>
+            </a>
+        </li>
+    </ul>
+</nav>
+{% endif %}
 {% endblock %}

--- a/myhpi/core/templatetags/minutes_tags.py
+++ b/myhpi/core/templatetags/minutes_tags.py
@@ -5,21 +5,23 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def next_minutes(context, minutes):
-    all_minutes = list(minutes.get_parent().specific.get_visible_minutes(context.request))
-    try:
-        i = all_minutes.index(minutes)
-        if i > 0:
-            return all_minutes[i - 1]
-    except ValueError:
-        return
+    # This may be None if there is no next minutes.
+    return (
+        minutes.get_parent()
+        .specific.get_visible_minutes(context.request)
+        .exclude(basepage_ptr_id__lte=minutes.basepage_ptr_id, date=minutes.date)
+        .filter(date__gte=minutes.date)
+        .order_by("date", "basepage_ptr_id")
+    ).first()
 
 
 @register.simple_tag(takes_context=True)
 def prev_minutes(context, minutes):
-    all_minutes = list(minutes.get_parent().specific.get_visible_minutes(context.request))
-    try:
-        i = all_minutes.index(minutes)
-        if i != len(all_minutes) - 1:
-            return all_minutes[i + 1]
-    except ValueError:
-        return
+    # This may be None if there is no previous minutes.
+    return (
+        minutes.get_parent()
+        .specific.get_visible_minutes(context.request)
+        .exclude(basepage_ptr_id__gte=minutes.basepage_ptr_id, date=minutes.date)
+        .filter(date__lte=minutes.date)
+        .order_by("-date", "-basepage_ptr_id")
+    ).first()

--- a/myhpi/locale/de/LC_MESSAGES/django.po
+++ b/myhpi/locale/de/LC_MESSAGES/django.po
@@ -135,10 +135,14 @@ msgstr "Vorheriges Protokoll"
 msgid "Next minutes"
 msgstr "Nächstes Protokoll"
 
-#: myhpi/core/templates/core/minutes_list.html:15
+#: myhpi/core/templates/core/minutes_list.html:14
 #: myhpi/core/templates/core/sidebar.html:7
 msgid "Page has unpublished changes!"
 msgstr "Seite hat unveröffentlichte Änderungen!"
+
+#: myhpi/core/templates/core/minutes_list.html:33
+msgid "No minutes available for this year."
+msgstr "Keine Protokolle für dieses Jahr verfügbar."
 
 #: myhpi/core/templates/core/sidebar.html:13
 msgid "Visibility"


### PR DESCRIPTION
Closes #193 

This adds year based pagination for minutes lists. By default, the year with the newest minutes is shown (if there are no minutes at all, the current year is shown).

I looks approximately like this:

![image](https://github.com/fsr-de/myHPI/assets/48409110/c6e3c03d-a32a-41b0-84a9-ece4c525547a)

If there are no more years in any direction, the `...` disappear` and if the smallest / largest year is selected, the arrow-button is disabled:

![image](https://github.com/fsr-de/myHPI/assets/48409110/e70d45bd-5fd5-4653-a5e6-191dee5ff009)
