### PR TITLE
Deal with Empty Ballots (And Test Correct Behaviour)

### DIFF
--- a/myhpi/polls/models.py
+++ b/myhpi/polls/models.py
@@ -234,7 +234,8 @@ class RankedChoicePoll(BasePoll):
             names[option.pk] = option.name
 
         for ballot in ballots:
-            current_votes[heapq.heappop(ballot)[1].option.pk].append(ballot)
+            if ballot:
+                current_votes[heapq.heappop(ballot)[1].option.pk].append(ballot)
 
         def find_loosers():
             threshold = min(map(lambda key: len(current_votes[key]), current_votes.keys()))

--- a/myhpi/tests/polls/test_ranked_choice_algorithm.py
+++ b/myhpi/tests/polls/test_ranked_choice_algorithm.py
@@ -111,6 +111,13 @@ class RankedChoiceAlgorithmTests(MyHPIPageTestCase):
             [(1, "Alice", 0), (1, "Bob", 0), (1, "Charlie", 0), (1, "Dora", 0)],
         )
 
+    def test_empty_ballots(self):
+        self.cast_ballots([[]])
+        self.assertEqual(
+            self.poll.calculate_ranking(),
+            [(1, "Alice", 0), (1, "Bob", 0), (1, "Charlie", 0), (1, "Dora", 0)],
+        )
+
     def test_fast(self):
         self.cast_ballots(([["alice", "bob"]] * 1000) + ([["bob", "alice", "charlie"]] * 900))
 


### PR DESCRIPTION
As described by @lukasrad02, the current algorithm for ranked choice elections throws an exception if there is an empty ballot (i.e., a voter who ranked no choice but still submitted their ballot). I've fixed this error and implemented a test to check the behaviour.

# The Error
For reference: Here is where it previously broke

```
======================================================================
ERROR: test_empty_ballots (myhpi.tests.polls.test_ranked_choice_algorithm.RankedChoiceAlgorithmTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/beb/code/fsr/myHPI/myhpi/tests/polls/test_ranked_choice_algorithm.py", line 117, in test_empty_ballots
    self.poll.calculate_ranking(),
  File "/Users/beb/code/fsr/myHPI/myhpi/polls/models.py", line 237, in calculate_ranking
    current_votes[heapq.heappop(ballot)[1].option.pk].append(ballot)
IndexError: index out of range
```