### PR TITLE
Set language cookie when selecting language

### DIFF
--- a/myhpi/static/scss/footer.scss
+++ b/myhpi/static/scss/footer.scss
@@ -25,6 +25,12 @@
             text-decoration: underline;
         }
     }
+
+    .btn-link {
+        color: var(--bs-text-light);
+        text-decoration: none;
+        padding: 0;
+    }
 }
 
 @media screen and (min-width: 576px) {

--- a/myhpi/templates/footer.html
+++ b/myhpi/templates/footer.html
@@ -13,14 +13,12 @@
     <div class="footer-category">
       <h2>{% translate "Language" %}</h2>
       {% for translation in page.get_translations %}
-      <form id="language-form-{{ translation.locale }}" action="{% url 'set_language' %}" method="post" style="display: none;">
+      <form id="language-form-{{ translation.locale }}" action="{% url 'set_language' %}" method="post">
         {% csrf_token %}
-        <input name="next" type="hidden" value="{{ redirect_to }}">
+        <input name="next" type="hidden" value="{{ translation.url }}">
         <input type="hidden" name="language" value="{{ translation.locale.language_code }}">
+        <button class="btn btn-link" type="submit">{{ translation.locale }}</button>
       </form>
-      <a href="#" onclick="document.getElementById('language-form-{{ translation.locale }}').submit(); return false;">
-        {{ translation.locale }}
-      </a>
       {% endfor %}
     </div>
   </div>

--- a/myhpi/templates/footer.html
+++ b/myhpi/templates/footer.html
@@ -12,9 +12,16 @@
     {% endfor %}
     <div class="footer-category">
       <h2>{% translate "Language" %}</h2>
-        {% for translation in page.get_translations %}
-            <a href="{{ translation.url }}">{{ translation.locale }}</a>
-        {% endfor %}
+      {% for translation in page.get_translations %}
+      <form id="language-form-{{ translation.locale }}" action="{% url 'set_language' %}" method="post" style="display: none;">
+        {% csrf_token %}
+        <input name="next" type="hidden" value="{{ redirect_to }}">
+        <input type="hidden" name="language" value="{{ translation.locale.language_code }}">
+      </form>
+      <a href="#" onclick="document.getElementById('language-form-{{ translation.locale }}').submit(); return false;">
+        {{ translation.locale }}
+      </a>
+      {% endfor %}
     </div>
   </div>
 </footer>

--- a/myhpi/urls.py
+++ b/myhpi/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
         ".well-known/security.txt",
         RedirectView.as_view(url=os.path.join(settings.STATIC_URL, "security.txt")),
     ),
+    path("i18n/", include("django.conf.urls.i18n")),
     path("", include("myhpi.core.urls")),
 ]
 


### PR DESCRIPTION
Closes #559 

Using the set language view from Django: https://docs.djangoproject.com/en/5.0/topics/i18n/translation/#the-set-language-redirect-view, integrated into the existing links.

Using a form with hidden fields to achieve that.
