### PR TITLE
Quick-Fix for broken selectors in admin dark mode

### DIFF
--- a/myhpi/static/css/myHPI_admin.css
+++ b/myhpi/static/css/myHPI_admin.css
@@ -6,3 +6,24 @@
     left: 200px !important ;
     bottom: 40px !important;
 }
+
+@media(prefers-color-scheme: dark) {
+    .select2-container--default .select2-selection--single .select2-selection__rendered {
+        color: white !important;
+        background-color: inherit !important;
+    }
+
+    .select2-container--default .select2-selection--single,
+    .select2-container--default .select2-selection--multiple,
+    .select2-container--default .select2-selection--multiple .select2-selection__choice {
+        background-color: inherit !important;
+    }
+
+    .select2-container--default .select2-results__option[aria-selected="true"] {
+        background-color: inherit !important;
+    }
+
+    .select2-dropdown {
+        background-color: black !important;
+    }
+}

--- a/myhpi/static/css/myHPI_admin.css
+++ b/myhpi/static/css/myHPI_admin.css
@@ -15,11 +15,8 @@
 
     .select2-container--default .select2-selection--single,
     .select2-container--default .select2-selection--multiple,
-    .select2-container--default .select2-selection--multiple .select2-selection__choice {
-        background-color: inherit !important;
-    }
-
-    .select2-container--default .select2-results__option[aria-selected="true"] {
+    .select2-container--default .select2-selection--multiple .select2-selection__choice,
+    .select2-container--default .select2-results__option[aria-selected="true"]  {
         background-color: inherit !important;
     }
 


### PR DESCRIPTION
Fixes the main issues in dark mode addressed in #421 

This is not the nicest solution, but it helps us with working in the myHPI dark mode admin panel for now

![image](https://github.com/user-attachments/assets/dbab4ff1-6c08-4081-bad6-5bd08f72f147)
