### PR TITLE
Add options for mailing list footers without subscribe link

### DIFF
--- a/myhpi/locale/de/LC_MESSAGES/django.po
+++ b/myhpi/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-13 17:26+0100\n"
+"POT-Creation-Date: 2024-07-29 19:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -372,12 +372,16 @@ msgid "Mailing Lists"
 msgstr "Mailinglisten"
 
 #: myhpi/tenca_django/forms.py:15
-msgid "Not subscribed users are allowed to post."
-msgstr "Nichtmitglieder dürfen an diese Liste schreiben."
+msgid "Not subscribed users are allowed to post"
+msgstr "Nichtmitglieder dürfen an diese Liste schreiben"
 
 #: myhpi/tenca_django/forms.py:18
-msgid "Replies are addressed to the list per default."
-msgstr "Antworten gehen immer an den Verteiler."
+msgid "Replies are addressed to the list per default"
+msgstr "Antworten gehen immer an den Verteiler"
+
+#: myhpi/tenca_django/forms.py:21
+msgid "Footer contains invitation link"
+msgstr "Fußzeile beinhaltet Einladungslink"
 
 #: myhpi/tenca_django/models.py:30
 #: myhpi/tenca_django/templates/tenca_django/manage_list.html:6
@@ -428,7 +432,7 @@ msgstr "Deine Mitgliedschaften"
 
 #: myhpi/tenca_django/templates/tenca_django/delete_list.html:5
 #: myhpi/tenca_django/templates/tenca_django/delete_list.html:10
-#: myhpi/tenca_django/templates/tenca_django/manage_list.html:48
+#: myhpi/tenca_django/templates/tenca_django/manage_list.html:40
 msgid "Delete list"
 msgstr "Liste Löschen"
 
@@ -444,6 +448,7 @@ msgstr ""
 "\t"
 
 #: myhpi/tenca_django/templates/tenca_django/delete_list.html:20
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:499
 #, fuzzy
 #| msgid "Delete list"
 msgid "Delete"
@@ -480,11 +485,11 @@ msgstr "Teile diesen Link, um neue Mitglieder einzuladen:"
 msgid "List options"
 msgstr "Listeneinstellungen"
 
-#: myhpi/tenca_django/templates/tenca_django/manage_list.html:47
+#: myhpi/tenca_django/templates/tenca_django/manage_list.html:39
 msgid "Save"
 msgstr "Speichern"
 
-#: myhpi/tenca_django/templates/tenca_django/manage_list.html:51
+#: myhpi/tenca_django/templates/tenca_django/manage_list.html:43
 msgid "Members"
 msgstr "Mitglieder"
 
@@ -601,11 +606,6 @@ msgstr "Die Anmeldung von {email} auf {list} wurde rückgänig gemacht."
 
 #~ msgid "Draft"
 #~ msgstr "Entwurf"
-
-#, fuzzy
-#~| msgid "[missing link]"
-#~ msgid "[missing image]"
-#~ msgstr "[link fehlt]"
 
 #~ msgid "Sorry, this page could not be found."
 #~ msgstr ""

--- a/myhpi/tenca_django/forms.py
+++ b/myhpi/tenca_django/forms.py
@@ -12,10 +12,13 @@ class TencaNewListForm(Form):
 
 class TencaListOptionsForm(Form):
     notsubscribed_allowed_to_post = BooleanField(
-        label=_("Not subscribed users are allowed to post."), required=False
+        label=_("Not subscribed users are allowed to post"), required=False
     )
     replies_addressed_to_list = BooleanField(
-        label=_("Replies are addressed to the list per default."), required=False
+        label=_("Replies are addressed to the list per default"), required=False
+    )
+    footer_has_subscribe_link = BooleanField(
+        label=_("Footer contains invitation link"), required=False
     )
     # Fields should be named according to their respective setting on the tenca list object
 
@@ -24,6 +27,7 @@ class TencaListOptionsForm(Form):
         super().__init__(*args, **kwargs)
         for key, field in self.fields.items():
             field.initial = getattr(mailing_list, key)
+        self.label_suffix = ""
 
 
 class TencaMemberEditForm(Form):

--- a/myhpi/tenca_django/templates/tenca_django/manage_list.html
+++ b/myhpi/tenca_django/templates/tenca_django/manage_list.html
@@ -27,21 +27,13 @@
 	<h3>{% trans "List options" %}</h3>
     <form method="post">
         {% csrf_token %}
-        <div class="form-group">
-            <div class="form-check">
-                <input type="checkbox" name="notsubscribed_allowed_to_post" class="form-check-input" id="id_notsubscribed_allowed_to_post" checked="">
-                <label class="form-check-label" for="id_notsubscribed_allowed_to_post">
-                    Not subscribed users are allowed to post.
-                </label>
-            </div>
-        </div>
-        <div class="form-group">
-            <div class="form-check">
-                <input type="checkbox" name="replies_addressed_to_list" class="form-check-input" id="id_replies_addressed_to_list">
-                <label class="form-check-label" for="id_replies_addressed_to_list">
-                    Replies are addressed to the list per default.
-                </label>
-            </div>
+        <div class="form-group mb-3">
+            {% for field in form %}
+                <div class="form-check">
+                    {{ field|addcss:"form-check-input" }}
+                    {{ field.label }}
+                </div>
+            {% endfor %}
         </div>
 		<div class="form-group">
 			<button type="submit" class="btn btn-primary">{% trans 'Save' %}</button>

--- a/myhpi/tenca_django/templates/tenca_django/manage_list.html
+++ b/myhpi/tenca_django/templates/tenca_django/manage_list.html
@@ -31,7 +31,7 @@
             {% for field in form %}
                 <div class="form-check">
                     {{ field|addcss:"form-check-input" }}
-                    {{ field.label }}
+                    {{ field.label_tag }}
                 </div>
             {% endfor %}
         </div>

--- a/myhpi/tenca_django/templatetags/tenca_extras.py
+++ b/myhpi/tenca_django/templatetags/tenca_extras.py
@@ -9,3 +9,8 @@ def fqdn_ize(list_id):
     from myhpi.tenca_django.connection import connection
 
     return connection.fqdn_ize(list_id)
+
+
+@register.filter(name='addcss')
+def addcss(field, css):
+    return field.as_widget(attrs={"class":css})


### PR DESCRIPTION
This PR introduces a new checkbox in the list admin interface to en- and disable invite links in mailing list footers.

Additionally, a previous bug in the form rendering has been fixed: The initial values of the checkboxes did not correspond to the current mailing list settings.

Depends on <https://github.com/tzwenn/tenca/pull/1>

Closes #501 