### PR TITLE
Ensure correct overlay order of content, toc and side panel

### DIFF
--- a/myhpi/static/scss/myHPI.scss
+++ b/myhpi/static/scss/myHPI.scss
@@ -150,6 +150,7 @@ p {
 
 .side-panel-container {
     position: sticky;
+    z-index: 30;
     top: 6rem;
 }
 
@@ -285,6 +286,7 @@ img {
 
 #sidebar-toggle {
     position: sticky;
+    z-index: 20;
     transition: all 0.3s ease; // Equal to .xl-hide-on-scroll
     top: calc(1rem + var(--myhpi-navbar-visible-height));
 }
@@ -383,6 +385,7 @@ img {
 @media (pointer: coarse), (hover: none) {
     [title] {
         position: relative;
+        z-index: 10;
         display: inline-flex;
         justify-content: center;
     }


### PR DESCRIPTION
Close #587 

Known limitation: The sidebar can overlay the toc button. This can become apparent on mobile if the sidebar/footer is so long, that the user could scroll past that point. This is not expected to be the case often. Future releases may want to move more content into offcanvas panels (like already done with the toc), which reduces the height of the sidebar further.

![grafik](https://github.com/user-attachments/assets/35c96cea-1975-4f20-ac4e-217e4610874d)
