### PR TITLE
Ignore lists with missing hashes on the dashboard

### DIFF
--- a/myhpi/tenca_django/views.py
+++ b/myhpi/tenca_django/views.py
@@ -29,7 +29,10 @@ class TencaDashboard(LoginRequiredMixin, FormView):
     def get_context_data(self, **kwargs):
         email = self.request.user.email
         kwargs.setdefault(
-            "memberships", connection.get_owner_and_memberships(email, *alternative_emails(email))
+            "memberships",
+            connection.get_owner_and_memberships(
+                email, *alternative_emails(email), ignore_missing_hashes=True
+            ),
         )
         kwargs.setdefault("domain_addon", "@" + str(connection.domain))
         return super().get_context_data(**kwargs)


### PR DESCRIPTION
In our production instance, there are some mailing lists that have not been created with tenca and thus are lacking the tenca hash id. This causes an error on the server when somebody who is member of such a list visits the dashboard.

This PR sets a new flag when querying the lists from tenca to prevent the error to be raised.