### PR TITLE
fix: use djLint instead of djhtml in GitHub job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,10 +40,10 @@ jobs:
         run: |
           poetry run pylint --version
           poetry run pylint --fail-under=9 myhpi
-      - name: Lint templates with djhtml
+      - name: Lint templates with djLint
         run: |
-          poetry run djhtml --version
-          poetry run djhtml --check myhpi
+          poetry run djlint --version
+          poetry run djlint --lint myhpi
 
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Fixes GitHub pipeline by actually using djLint instead of djhtml