### PR TITLE
Bump Ubuntu version in GH Action runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: [3.11]
@@ -46,7 +46,7 @@ jobs:
           poetry run djlint --lint myhpi
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: [3.11, 3.12] # Also update Coveralls step when updating versions here


### PR DESCRIPTION
20.04 is deprecated and actions do not work anymore (see https://github.com/fsr-de/myHPI/actions/runs/15391157277/job/43317974106)

See also: https://github.com/actions/runner-images/issues/11101