### PR TITLE
Fix mailing list mange template

### DIFF
--- a/myhpi/tenca_django/templates/tenca_django/manage_list.html
+++ b/myhpi/tenca_django/templates/tenca_django/manage_list.html
@@ -108,7 +108,7 @@
                         </button>
                     </div>
                 </form>
-            </div>
-        {% endfor %}
+            {% endfor %}
+        </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Fix closing divs in `templates/tenca_django/manage_list.html`.

Resolves #676. 